### PR TITLE
Add libsodium from buildroot-2018.09.2

### DIFF
--- a/package/libsodium/Config.in
+++ b/package/libsodium/Config.in
@@ -1,0 +1,6 @@
+config BR2_PACKAGE_LIBSODIUM
+	bool "libsodium"
+	help
+	  A modern and easy-to-use crypto library.
+
+	  http://libsodium.org/

--- a/package/libsodium/libsodium.hash
+++ b/package/libsodium/libsodium.hash
@@ -1,0 +1,4 @@
+# Locally calculated after checking pgp signature
+# https://download.libsodium.org/libsodium/releases/libsodium-1.0.16.tar.gz.sig
+sha256 eeadc7e1e1bcef09680fb4837d448fbdf57224978f865ac1c16745868fbd0533  libsodium-1.0.16.tar.gz
+sha256 6faf327c97dca6da69acefc6d3969d7bffb70a24f0707874870fdcfd6b0acf58  LICENSE

--- a/package/libsodium/libsodium.mk
+++ b/package/libsodium/libsodium.mk
@@ -1,0 +1,18 @@
+################################################################################
+#
+# libsodium
+#
+################################################################################
+
+LIBSODIUM_VERSION = 1.0.16
+LIBSODIUM_SITE = https://github.com/jedisct1/libsodium/releases/download/$(LIBSODIUM_VERSION)
+LIBSODIUM_LICENSE = ISC
+LIBSODIUM_LICENSE_FILES = LICENSE
+LIBSODIUM_INSTALL_STAGING = YES
+
+ifeq ($(BR2_TOOLCHAIN_SUPPORTS_PIE),)
+LIBSODIUM_CONF_OPTS += --disable-pie
+endif
+
+$(eval $(autotools-package))
+$(eval $(host-autotools-package))


### PR DESCRIPTION
This is needed for the Diablo 1 (DevilutionX) port I'm working on.

Instead of including it in the firmware, I link it statically.

To build the static library all I need to do is add:

```
echo 'LIBSODIUM_CONF_OPTS += --enable-static' >> package/libsodium/libsodium.mk
```

I want to use this buildroot for building the binary instead of the upstream (buildroot.org) one to make sure I link against the same versions of all the libraries.