### PR TITLE
etna_viv.mk: Add libpng to package dependencies

### DIFF
--- a/package/etna_viv/etna_viv.mk
+++ b/package/etna_viv/etna_viv.mk
@@ -18,6 +18,8 @@ else ifeq ($(BR2_PACKAGE_ETNA_VIV),y)
 $(error No ABI version selected)
 endif
 
+ETNA_VIV_DEPENDENCIES = libpng
+
 define ETNA_VIV_BUILD_CMDS
 	$(MAKE) -C $(@D)/attic \
 		GCCPREFIX="$(TARGET_CROSS)" \


### PR DESCRIPTION
Depends on libpng:
attic/lib/read_png.c (https://github.com/laanwj/etna_viv/blob/d4c87f61bdcd15f98d4bdbea8c34788bb71fbad9/attic/lib/read_png.c#L8) used in attic/test2d
(https://github.com/laanwj/etna_viv/blob/d4c87f61bdcd15f98d4bdbea8c34788bb71fbad9/attic/test2d/Makefile#L14)