### PR TITLE
do resize2fs for mmcblk0p2 on boot

### DIFF
--- a/board/opendingux/gcw0/target_skeleton/etc/udev/rules.d/61-automount.rules
+++ b/board/opendingux/gcw0/target_skeleton/etc/udev/rules.d/61-automount.rules
@@ -15,10 +15,12 @@ ACTION=="add", ENV{dir_name}!="?*", PROGRAM=="/sbin/blkid -o value -p -s LABEL %
 ACTION=="add", KERNEL=="mmcblk1p1", ENV{dir_name}!="?*", ENV{dir_name}="sdcard"
 ACTION=="add", ENV{dir_name}!="?*", ENV{dir_name}="%k"
 
+ACTION=="add", KERNEL=="mmcblk0p2", RUN+="/usr/sbin/e2fsck -f -y /dev/%k"
+
 ACTION=="add", ENV{dir_name}=="?*", RUN+="/bin/mount -o remount,rw /media", RUN+="/bin/mkdir -p '/media/%E{dir_name}'", RUN+="/bin/mount -o %E{mount_options} /dev/%k '/media/%E{dir_name}'", RUN+="/bin/mount -o remount,ro /media"
 ACTION=="remove", ENV{dir_name}=="?*", RUN+="/bin/umount -l '/media/%E{dir_name}'", RUN+="/bin/mount -o remount,rw /media", RUN+="/bin/rmdir '/media/%E{dir_name}'", RUN+="/bin/mount -o remount,ro /media"
 
 # Inform that /media/data is mounted (S15localfsinit.sh needs this).
-ACTION=="add", KERNEL=="mmcblk0p2", RUN+="/bin/touch /tmp/.media_data_is_mounted"
+ACTION=="add", KERNEL=="mmcblk0p2", RUN+="/bin/touch /tmp/.media_data_is_mounted", RUN+="/usr/sbin/resize2fs /dev/%k"
 
 LABEL="media_by_label_auto_mount_end" 


### PR DESCRIPTION
so that we do not need to resize 2nd partition of internal microsd after reflashing new firmware images