### PR TITLE
Add SDL2 controller mappings for RG350

### DIFF
--- a/package/sdl2/0001-RG350-SDL2-controller-mappings.patch
+++ b/package/sdl2/0001-RG350-SDL2-controller-mappings.patch
@@ -1,0 +1,24 @@
+From 68554ae95fbe714caf797141dc633aac2374915d Mon Sep 17 00:00:00 2001
+From: Gleb Mazovetskiy <glex.spb@gmail.com>
+Date: Sun, 8 Dec 2019 13:58:24 +0000
+Subject: [PATCH] RG350 SDL2 controller mappings
+
+---
+ src/joystick/SDL_gamecontrollerdb.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/joystick/SDL_gamecontrollerdb.h b/src/joystick/SDL_gamecontrollerdb.h
+index 99aaa3c..bcefcfa 100644
+--- a/src/joystick/SDL_gamecontrollerdb.h
++++ b/src/joystick/SDL_gamecontrollerdb.h
+@@ -31,6 +31,7 @@
+  */
+ static const char *s_ControllerMappings [] =
+ {
++    "190000006c696e6b6465762064657600,RG350,platform:Linux,x:b3,a:b0,b:b1,y:b2,back:b8,start:b9,dpleft:h0.8,dpdown:h0.4,dpright:h0.2,dpup:h0.1,leftshoulder:b4,lefttrigger:b6,rightshoulder:b5,righttrigger:b7,leftstick:b10,rightstick:b11,leftx:a0,lefty:a1,rightx:a2,righty:a3,",
+ #ifdef SDL_JOYSTICK_DINPUT
+     "341a3608000000000000504944564944,Afterglow PS3 Controller,a:b1,b:b2,back:b8,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,guide:b12,leftshoulder:b4,leftstick:b10,lefttrigger:b6,leftx:a0,lefty:a1,rightshoulder:b5,rightstick:b11,righttrigger:b7,rightx:a2,righty:a3,start:b9,x:b0,y:b3,",
+     "ffff0000000000000000504944564944,GameStop Gamepad,a:b0,b:b1,back:b8,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,guide:,leftshoulder:b4,leftstick:b10,lefttrigger:b6,leftx:a0,lefty:a1,rightshoulder:b5,rightstick:b11,righttrigger:b7,rightx:a2,righty:a3,start:b9,x:b2,y:b3,",
+--
+2.20.1
+


### PR DESCRIPTION
With this controls in SDL2 games should work out of the box, with no need for custom RG350 code.