### PR TITLE
pcsx4all: Switch to Tonyjih/RG350_pcsx4all repo

### DIFF
--- a/board/opendingux/package/pcsx4all/pcsx4all.mk
+++ b/board/opendingux/package/pcsx4all/pcsx4all.mk
@@ -3,29 +3,17 @@
 # pcsx4all
 #
 ################################################################################
-PCSX4ALL_VERSION = 765c2a9
-PCSX4ALL_SITE = $(call github,gameblabla,pcsx4all,$(PCSX4ALL_VERSION))
+PCSX4ALL_VERSION = master
+PCSX4ALL_SITE = $(call github,tonyjih,RG350_pcsx4all,$(PCSX4ALL_VERSION))
 PCSX4ALL_AUTORECONF = YES
 PCSX4ALL_INSTALL_STAGING = YES
+PCSX4ALL_DEPENDENCIES = sdl sdl_mixer sdl_image
 
 PCSX4ALL_MAKE_OPTS = \
 	MD="mkdir -p" \
     CC="$(TARGET_CC)" \
     CXX="$(TARGET_CXX)" \
     LD="$(TARGET_CXX)" \
-
-# BEGIN hacks for older buildroot
-# Remove -flto
-# Remove -mframe-header-opt and replace with -std=c99
-# Add -lpthread -lrt
-define PCSX4ALL_PREPARE_BUILD
-    (   cd $(@D) ; \
-		sed -i 's/-flto//g' Makefile.gcw0 ; \
-        sed -i 's/-mframe-header-opt/-std=c99/g' Makefile.gcw0 ; \
-        sed -i 's/LDFLAGS = /LDFLAGS = -lpthread -lrt /g' Makefile.gcw0)
-endef
-PCSX4ALL_PRE_CONFIGURE_HOOKS += PCSX4ALL_PREPARE_BUILD
-# END hacks
 
 define PCSX4ALL_BUILD_CMDS
     $(MAKE) $(PCSX4ALL_MAKE_OPTS) -C $(@D) \


### PR DESCRIPTION
It's faster due to IPU scaling.

Also specifies dependencies and removes unnecessary build hacks

[pcsx4all.opk.zip](https://github.com/tonyjih/RG350_buildroot/files/3958512/pcsx4all.opk.zip)