### PR TITLE
Update freetype to 2.10.1

### DIFF
--- a/package/freetype/Config.in
+++ b/package/freetype/Config.in
@@ -3,4 +3,4 @@ config BR2_PACKAGE_FREETYPE
 	help
 	  a free, high-quality and portable font engine.
 
-	  http://www.freetype.org/
+	  https://www.freetype.org/

--- a/package/freetype/freetype.hash
+++ b/package/freetype/freetype.hash
@@ -1,0 +1,9 @@
+# From https://sourceforge.net/projects/freetype/files/freetype2/2.10.1/
+md5 bd42e75127f8431923679480efb5ba8f freetype-2.10.1.tar.xz
+sha1 79874ef4eaa52025126b71d836453b8279bdd331 freetype-2.10.1.tar.xz
+
+# Locally calculated
+sha256	16dbfa488a21fe827dc27eaf708f42f7aa3bb997d745d31a19781628c36ba26f	freetype-2.10.1.tar.xz
+sha256	fd056de4196903a676208ef58cfddafc7d583d1f28fa2e44c309cf84a59e62fb	docs/LICENSE.TXT
+sha256	08c135755dd589039470f1fdbb400daaabaaa50d0b366d19cebff4d22986baa1	docs/FTL.TXT
+sha256	c4120c6752c910c299e3bd9cb3a46ff262c268303ca2069b61f92f10a5656c18	docs/GPLv2.TXT

--- a/package/freetype/freetype.mk
+++ b/package/freetype/freetype.mk
@@ -4,31 +4,22 @@
 #
 ################################################################################
 
-FREETYPE_VERSION = 2.5.3
-FREETYPE_SOURCE = freetype-$(FREETYPE_VERSION).tar.bz2
-FREETYPE_SITE = http://downloads.sourceforge.net/project/freetype/freetype2/$(FREETYPE_VERSION)
+FREETYPE_VERSION = 2.10.1
+FREETYPE_SOURCE = freetype-$(FREETYPE_VERSION).tar.xz
+FREETYPE_SITE = http://download.savannah.gnu.org/releases/freetype
 FREETYPE_INSTALL_STAGING = YES
 FREETYPE_MAKE_OPT = CCexe="$(HOSTCC)"
-FREETYPE_LICENSE = Dual FTL/GPLv2+
-FREETYPE_LICENSE_FILES = docs/FTL.TXT docs/GPLv2.TXT
+FREETYPE_LICENSE = Dual FTL/GPL-2.0+
+FREETYPE_LICENSE_FILES = docs/LICENSE.TXT docs/FTL.TXT docs/GPLv2.TXT
 FREETYPE_DEPENDENCIES = host-pkgconf
 FREETYPE_CONFIG_SCRIPTS = freetype-config
 
 HOST_FREETYPE_DEPENDENCIES = host-pkgconf
 HOST_FREETYPE_CONF_OPT = --without-zlib --without-bzip2 --without-png
 
-# Regen required because the tarball ships with an experimental ltmain.sh
-# that can't be patched by our infra.
-# autogen.sh is because autotools stuff lives in other directories and
-# even AUTORECONF with _OPT doesn't do it properly.
-# POST_PATCH is because we still need to patch libtool after the regen.
-define FREETYPE_RUN_AUTOGEN
-	cd $(@D) && PATH=$(BR_PATH) ./autogen.sh
-endef
-FREETYPE_POST_PATCH_HOOKS += FREETYPE_RUN_AUTOGEN
-HOST_FREETYPE_POST_PATCH_HOOKS += FREETYPE_RUN_AUTOGEN
-FREETYPE_DEPENDENCIES += host-automake host-autoconf host-libtool
-HOST_FREETYPE_DEPENDENCIES += host-automake host-autoconf host-libtool
+# since 2.9.1 needed for freetype-config install
+FREETYPE_CONF_OPT += --enable-freetype-config
+HOST_FREETYPE_CONF_OPT += --enable-freetype-config
 
 ifeq ($(BR2_PACKAGE_ZLIB),y)
 FREETYPE_DEPENDENCIES += zlib
@@ -70,34 +61,5 @@ define FREETYPE_FIX_CONFIG_FILE_LIBS
 endef
 FREETYPE_POST_INSTALL_STAGING_HOOKS += FREETYPE_FIX_CONFIG_FILE_LIBS
 
-# Version 2.5.1 reorganized headers out of freetype2/freetype.
-# It is unexpected for some packages so symlink it until it spreads
-# upstream. Note that we also have to remove the symlink prior to the
-# installation process, because the installation process of freetype
-# removes usr/include/Freetype2/freetype/config, before installing
-# something in usr/include/Freetype2/config/ which no longer exists
-# due to the symbolic link.
-define FREETYPE_REMOVE_FREETYPE_INCLUDE_SYMLINK
-	$(RM) -f $(STAGING_DIR)/usr/include/freetype2/freetype
-endef
-FREETYPE_PRE_INSTALL_STAGING_HOOKS += FREETYPE_REMOVE_FREETYPE_INCLUDE_SYMLINK
-define FREETYPE_FIX_FREETYPE_INCLUDE
-	ln -sf . $(STAGING_DIR)/usr/include/freetype2/freetype
-endef
-FREETYPE_POST_INSTALL_STAGING_HOOKS += FREETYPE_FIX_FREETYPE_INCLUDE
-
-define HOST_FREETYPE_REMOVE_FREETYPE_INCLUDE_SYMLINK
-	$(RM) -f $(HOST_DIR)/usr/include/freetype2/freetype
-endef
-HOST_FREETYPE_PRE_INSTALL_HOOKS += HOST_FREETYPE_REMOVE_FREETYPE_INCLUDE_SYMLINK
-define HOST_FREETYPE_FIX_FREETYPE_INCLUDE
-	ln -sf . $(HOST_DIR)/usr/include/freetype2/freetype
-endef
-HOST_FREETYPE_POST_INSTALL_HOOKS += HOST_FREETYPE_FIX_FREETYPE_INCLUDE
-
 $(eval $(autotools-package))
 $(eval $(host-autotools-package))
-
-# freetype-patch uses autogen.sh so add it as a order-only-prerequisite
-# because it is a phony target.
-$(FREETYPE_TARGET_PATCH): | host-automake


### PR DESCRIPTION
The newer versions of freetype come with the Harmony subpixel rendering algorithm.

Note that subpixel rendering only applies to `FT_RENDER_MODE_LCD(_V)`. There is no way to set this mode via `SDL_ttf`, I'll try to add this functionality to SDL_ttf in the future.