### PR TITLE
Switch DinguxCommander to glebm's fork

### DIFF
--- a/board/opendingux/package/dingux-commander/Config.in
+++ b/board/opendingux/package/dingux-commander/Config.in
@@ -2,8 +2,7 @@ config BR2_PACKAGE_DINGUX_COMMANDER
 	bool "DinguxCommander"
 	select BR2_PACKAGE_SDL
 	select BR2_PACKAGE_SDL_IMAGE
-	select BR2_PACKAGE_SDL_TTF
 	help
 	  Two-pane file manager in the style of Norton Commander.
 
-	  http://beyondds.free.fr/index.php?Dingoo-dinguxcommander
+	  https://github.com/glebm/rs97-commander/

--- a/board/opendingux/package/dingux-commander/dingux-commander.mk
+++ b/board/opendingux/package/dingux-commander/dingux-commander.mk
@@ -4,29 +4,17 @@
 #
 ################################################################################
 
-DINGUX_COMMANDER_VERSION = master
-DINGUX_COMMANDER_SITE = $(call github,gcwnow,DinguxCommander,$(DINGUX_COMMANDER_VERSION))
-DINGUX_COMMANDER_DEPENDENCIES = sdl sdl_image sdl_ttf
+DINGUX_COMMANDER_VERSION = stable
+DINGUX_COMMANDER_SITE = $(call github,glebm,rs97-commander,$(DINGUX_COMMANDER_VERSION))
+DINGUX_COMMANDER_DEPENDENCIES = sdl sdl_image freetype
 
-DINGUX_COMMANDER_RESDIR = /usr/share/DinguxCommander
-DINGUX_COMMANDER_CONFIG = opendingux-$(BR2_TOOLCHAIN_BUILDROOT_VENDOR)
-
-define DINGUX_COMMANDER_BUILD_CMDS
-	$(MAKE) CXX="$(TARGET_CXX)" RESDIR="$(DINGUX_COMMANDER_RESDIR)" SDL_CONFIG="$(STAGING_DIR)/usr/bin/sdl-config" LD="$(TARGET_LD)" CONFIG=$(DINGUX_COMMANDER_CONFIG) -C $(@D)
-endef
-
-ifeq ($(BR2_PACKAGE_GMENU2X),y)
-DINGUX_COMMANDER_DEPENDENCIES += gmenu2x
-define DINGUX_COMMANDER_INSTALL_TARGET_GMENU2X
-	$(INSTALL) -m 0644 -D $(BR2_EXTERNAL)/package/dingux-commander/gmenu2x $(TARGET_DIR)/usr/share/gmenu2x/sections/applications/25_DinguxCommander
-endef
-endif
+DINGUX_COMMANDER_TARGET_PLATFORM = rg350
+DINGUX_COMMANDER_OPT += -DTARGET_PLATFORM=$(DINGUX_COMMANDER_TARGET_PLATFORM)
 
 define DINGUX_COMMANDER_INSTALL_TARGET_CMDS
-	$(INSTALL) -m 0755 -D $(@D)/output/$(DINGUX_COMMANDER_CONFIG)/DinguxCommander $(TARGET_DIR)/usr/bin/DinguxCommander
-	$(INSTALL) -m 0755 -d $(TARGET_DIR)/$(DINGUX_COMMANDER_RESDIR)/
-	$(INSTALL) -m 0644 -t $(TARGET_DIR)/$(DINGUX_COMMANDER_RESDIR)/ $(@D)/res/*
-	$(DINGUX_COMMANDER_INSTALL_TARGET_GMENU2X)
+	mkdir -p $(BINARIES_DIR)/opks
+	cd $(@D) && ./package-opk.sh $(DINGUX_COMMANDER_TARGET_PLATFORM) $(DINGUX_COMMANDER_BUILDDIR) \
+	  $(BINARIES_DIR)/opks/commander.opk
 endef
 
-$(eval $(generic-package))
+$(eval $(cmake-package))

--- a/board/opendingux/package/dingux-commander/gmenu2x
+++ b/board/opendingux/package/dingux-commander/gmenu2x
@@ -1,4 +1,0 @@
-title=DinguxCmdr
-description=Two-pane file manager
-exec=/usr/bin/DinguxCommander
-icon=skin:icons/dinguxcmdr.png


### PR DESCRIPTION
glebm's fork is an improved version of DinguxCommander with
some new features and many bug fixes, packaged as OPK.

See https://github.com/glebm/rs97-commander/releases/tag/2020-03-06

@soarqin @tonyjih 