### PR TITLE
Fix libshake symlinks

### DIFF
--- a/board/opendingux/package/libshake/libshake.mk
+++ b/board/opendingux/package/libshake/libshake.mk
@@ -21,8 +21,12 @@ endef
 
 define LIBSHAKE_INSTALL_TARGET_CMDS
 	$(LIBSHAKE_MAKE_ENV) DESTDIR="$(TARGET_DIR)" $(MAKE) -C $(@D) install-lib
+	# The libshake.so symlink is incorrect as it points to the absolute path. Fix it.
+	# Upstream fix in review: https://github.com/zear/libShake/pull/18
+	ln -sf libshake.so.2 "$(TARGET_DIR)/usr/lib/libshake.so"
+
 	# libshake.so.1 symlink for backwards compatibility with existing OPKs
-	ln -sf "$(TARGET_DIR)/usr/lib/libshake.so.2" "$(TARGET_DIR)/usr/lib/libshake.so.1"
+	ln -sf libshake.so.2 "$(TARGET_DIR)/usr/lib/libshake.so.1"
 endef
 
 $(eval $(generic-package))


### PR DESCRIPTION
It was pointing at the absolute path during build time, so was never actually found on the device.